### PR TITLE
Rename gent.txt to ugent.txt

### DIFF
--- a/domains/be/gent.txt
+++ b/domains/be/gent.txt
@@ -1,1 +1,0 @@
-Ghent University

--- a/domains/be/ugent.txt
+++ b/domains/be/ugent.txt
@@ -1,0 +1,1 @@
+Ghent University


### PR DESCRIPTION
The Ghent University domain is `ugent.be`. `gent.be` is the city domain.